### PR TITLE
Fix over 53bit XOR clipping

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,7 @@
     "mocha": "^5.0.0",
     "power-assert": "^1.4.4"
   },
-  "dependencies": {}
+  "dependencies": {
+    "bitwise64": "^1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scatter-swap",
   "description": "scatter_swap for JavaScript",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "homepage": "https://github.com/hoco/scatter-swap-js/",
   "repository": {
     "type": "git",

--- a/src/scatter_swap.js
+++ b/src/scatter_swap.js
@@ -1,4 +1,5 @@
 "use strict";
+const b64 = require("bitwise64");
 
 export default class ScatterSwap  {
   constructor (originalInteger, spin = 0, digit = 10) {
@@ -49,7 +50,7 @@ export default class ScatterSwap  {
   swapperMap(index) {
     let array = this.numbers();
     return this.numbers().map((i) => {
-      return this.rotate(array, index + i ^ this.spin).pop();
+      return this.rotate(array, b64.xor(index + i, this.spin)).pop();
     });
   }
 
@@ -68,7 +69,7 @@ export default class ScatterSwap  {
   scatter() {
     let sumOfDigits = this.workingArray.reduce((pre, curr) => pre + curr);
     this.workingArray = this.digitArray.map(() => {
-      return this.rotate(this.workingArray, this.spin ^ sumOfDigits).pop();
+      return this.rotate(this.workingArray, b64.xor(this.spin, sumOfDigits)).pop();
     });
   }
 
@@ -79,7 +80,7 @@ export default class ScatterSwap  {
 
     this.digitArray.forEach(() => {
       this.workingArray.push(scatteredArray.pop());
-      this.workingArray = this.rotate(this.workingArray, (sumOfDigits ^ this.spin) * -1);
+      this.workingArray = this.rotate(this.workingArray, b64.xor(sumOfDigits, this.spin) * -1);
     });
   }
 }

--- a/test/scatter_swap_test.js
+++ b/test/scatter_swap_test.js
@@ -53,6 +53,17 @@ describe("ScatterSwap", () => {
           assert(target == reverseHashed);
         }
       });
+      context("64bit spin", () => {
+        it("should be reversible", () => {
+          for (let i = 0; i < 100; i++) {
+            const target = randomDigits(10);
+            const spin = randomDigits(9) + 9000000000;
+            const hashed = new ScatterSwap(target, spin).hash();
+            const reverseHashed = new ScatterSwap(Number(hashed), spin).reverseHash();
+            assert(target == reverseHashed);
+          }
+        });
+      });
     });
     context("specify digits", () => {
       it("should be specified digits", () => {


### PR DESCRIPTION
If a spin is over 53bit integer, scater-swap-js can't transform the number correctly.

See: https://stackoverflow.com/questions/2983206/bitwise-and-in-javascript-with-a-64-bit-integer